### PR TITLE
Build apalache for  integration tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# inherit the environment from the apalache git submodule
+[[ -f apalache/.envrc ]] && source apalache/.envrc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,3 +83,51 @@ jobs:
           source .venv/bin/activate
           pyright chai/ tests/
           pytest tests/
+
+  integration:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # We need non-shallow git clone for nix
+          fetch-depth: 0
+          # We need the apalache code base git submodule for the integration tests
+          submodules: "recursive"
+      - name: Cache local m2 repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-sbt-${{ hashFiles('project/Dependencies.scala') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+            ${{ runner.os }}-
+      - name: Cache nix store
+        # Workaround for cache action not playing well with permissions
+        # See https://github.com/actions/cache/issues/324
+        uses: john-shaffer/cache@59429c0461095f341a8cf7388e5d3aef37b95edd
+        with:
+          path: |
+            /nix/store
+            /nix/var/nix/profiles
+          key: ${{ runner.os }}-nix-${{ hashFiles('**.nix') }}
+          restore-keys: |
+            ${{ runner.os }}-nix-
+            ${{ runner.os }}-
+      - name: Install Nix
+        uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
+          install_options: "--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve"
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Build Apalache
+        run: make apalache
+      - name: Ensure Apalache is built
+        run: |
+          source .envrc
+          apalache-mc version

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ APALACHE_PROTO := apalache/shai/src/main/protobuf
 # See this issue details: https://github.com/protocolbuffers/protobuf/issues/1491
 CHAI_PROTO := proto/chai
 
+.PHONY: apalache
+
 update-grpc: chai/transExplorer_pb2.py chai/transExplorer_pb2_grpc.py chai/transExplorer_pb2.pyi chai/transExplorer_pb2_grpc.pyi
 
 $(CHAI_PROTO):
@@ -36,3 +38,10 @@ chai/%_pb2.py chai/%_pb2.pyi chai/%_pb2_grpc.py chai/%_pb2_grpc.pyi: $(CHAI_PROT
 		--grpc_python_out=. \
 		--mypy_grpc_out=. \
 		$(CHAI_PROTO)/$*.proto
+
+# Build the apalache executable for intgration tests
+#
+# We build apalache using the nix flake to ensure all build dependendcies
+# are picked up from the apalache configuration
+apalache:
+	cd apalache && nix develop -c bash -c "make package"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ submodule, then regenerate the gRPC code, e.g.,
 pushd apalache && git pull && popod
 make update-grpc
 ```
+
+### Integration tests
+
+#### Dependencies
+
+- [The nix package manager with flakes enabled](https://github.com/informalsystems/cosmos.nix#non-nixos)
+
+The reason for depending on nix for our integration test is as follows: To run
+the integration tests, we need the version of Apalache included as a git
+submodule. We ensure the version is kept in sync by building the Apalache
+executable from the git submodule we use to obtain the proto files, and to
+ensure that we have all build dependencies for that build, we reuse Apalache's
+`flake.nix`.


### PR DESCRIPTION
Closes #11 

## Overview

Sets up a make build target and a CI job to build Apalache and make it available in the project's path (via direnv), thus providing the precondition for #8.

## Changes

- Source the .envrc from the apalache submodule, bringing apalche-mc into the `PATH` for the project
- Add a simple make target to build apalache
- Add a job to the CI for integration tests