### PR TITLE
Use asyncio for the concurrent executions of RPC calls from the client to the server

### DIFF
--- a/chai/__init__.py
+++ b/chai/__init__.py
@@ -1,3 +1,3 @@
-from chai.chai import Chai
+from chai.chai import Chai, NoServerConnection
 
-__all__ = ["Chai"]
+__all__ = ["Chai", "NoServerConnection"]

--- a/chai/chai.py
+++ b/chai/chai.py
@@ -78,7 +78,7 @@ class Chai:
         )
         return self
 
-    def isConnected(self) -> bool:
+    def is_connected(self) -> bool:
         """True if the client has an open connection"""
         return self._conn is not None
 

--- a/chai/chai.py
+++ b/chai/chai.py
@@ -1,5 +1,9 @@
 """The gRPC client to interact with Apalache's Shai server"""
 
+# TODO: Mypy can't currently generate stubs for the grpc.aio code, so we have a
+# few `type: ignore` annotations scattered around. Remove these when
+# https://github.com/nipunn1313/mypy-protobuf/issues/216 is closed.
+
 # Postpone evaluation of annotations
 # see:
 #  - https://stackoverflow.com/a/33533514/1187277
@@ -7,16 +11,27 @@
 #
 from __future__ import annotations
 
-from types import TracebackType
-from typing import Optional, Type, TypeVar
-import grpc
+import asyncio
+from collections.abc import AsyncIterator, Awaitable
+from contextlib import asynccontextmanager
+from typing import Any, Optional, TypeVar
+
+# TODO remove `type: ignore` when stubs are available for grpc.aio See
+# https://github.com/shabbyrobe/grpc-stubs/issues/22
+import grpc.aio as aio  # type: ignore
+from grpc import ChannelConnectivity
+
 import chai.transExplorer_pb2 as msg
 import chai.transExplorer_pb2_grpc as service
 
 T = TypeVar("T")
 
 
-class Chai:
+class NoServerConnection(Exception):
+    """Raised if client cannot connect to server after timeout expires"""
+
+
+class Chai(Awaitable):
     """Client for Human-Apalache Interaction
 
     This class implements the contextmanager protocol, and is meant to be used in
@@ -25,22 +40,23 @@ class Chai:
     Example usage:
 
     ```
-    import chai
+    from chai import Chai
 
-    with chai.Chai() as client:
+    with Chai.create() as client:
+        assert client.is_connected()
         # TODO: Add key method invocations
-        pass
     ```
 
     If you need to use the class outside of a `with` statement, be sure to
     obtain a connection before doing your work and to close the client when done:
 
     ```
+    client = Chai()
     try:
-      client = chai.Chai().connect()
-      # Do stuff
+        client.connect()
+        # Do more stuff
     finally:
-      client.close()
+        client.close()
     ```
 
     All methods aside from `connect` assume a connection has been obtained.
@@ -50,39 +66,111 @@ class Chai:
     DEFAULT_DOMAIN = "localhost"
     DEFAULT_PORT = 8822
 
-    def __init__(self, ip: str = DEFAULT_DOMAIN, port: int = DEFAULT_PORT) -> None:
-        self._channel = grpc.insecure_channel(f"{ip}:{port}")
-        self._conn: Optional[msg.Connection] = None
+    # The `create` class method lets us use grpcio.aio's async context manager
+    # to safely manage the state of the channel, and provide the user with an
+    # instance of the Chai client in that context.
+    @classmethod
+    @asynccontextmanager
+    async def create(cls, *args: Any, **kwargs: Any) -> AsyncIterator[Chai]:
+        """Async context manager to create a Chai client with managed resources
+
+        This is the recommended way to create a client, as it ensures that the
+        connections and any other resources are cleaned up on exit.
+
+        Example usage:
+
+        ```
+        async with Chai.create() as client:
+            # interact with the server
+        ```
+        """
+        client = cls(*args, **kwargs)
         try:
-            self._stub = service.TransExplorerStub(self._channel)
-        except Exception as e:
-            self.close()
-            raise e
+            async with aio.insecure_channel(client._channel_spec) as channel:
+                await client.connect(channel)
+                yield client
+        finally:
+            # To ensure any resources besides the channel are also cleaned up
+            await client.close()
 
-    def __enter__(self) -> Chai:
-        return self.connect()
+    def __init__(
+        self,
+        domain: str = DEFAULT_DOMAIN,
+        port: int = DEFAULT_PORT,
+        timeout: float = 60.0,
+    ) -> None:
+        """Initialize the Chai client.
 
-    def __exit__(self, type: Type[T], value: T, traceback: TracebackType) -> None:
-        # Unused variables
-        _ = (type, value, traceback)
-        self.close()
+        Args:
 
-    def connect(self) -> Chai:
+            domain: domain name or IP where the Apalache server is running
+            port: port to which the Apalache server is connected
+            timeout: how long to wait before giving up when trying to connect to
+                the server (default: 60 seconds)
+        """
+        self._channel_spec = f"{domain}:{port}"
+
+        self._timeout = timeout
+
+        self._channel: Optional[aio.Channel] = None
+        self._stub: Optional[service.TransExplorerStub] = None
+        self._conn: Optional[msg.Connection] = None
+
+    # We need the client to implement the await protocol
+    def __await__(self):
+        async def closure():
+            return self
+
+        return closure().__await__()
+
+    async def connect(self, channel: Optional[aio.Channel] = None) -> Chai:
         """Obtain a connection from the server
 
         All other methods assume a connection has been obtained. This method is
         called automatically when the class is used as a context manager.
+
+        If you call this method directly, you should be sure to call
+        `self.close()` to ensure the connection and channel is
         """
-        self._conn: Optional[msg.Connection] = self._stub.OpenConnection(
-            msg.ConnectRequest()
-        )
-        return self
+        if channel is None:
+            # No channel is provided, so we create an unmanaged channel,
+            # which the caller must close via `self.close()`
+            self._channel = aio.insecure_channel(self._channel_spec)
+        else:
+            # We assume the caller is managing the channel (i.e., via a `with`
+            # statement)
+            self._channel = channel
+
+        self._stub = service.TransExplorerStub(self._channel)
+
+        req = msg.ConnectRequest()
+
+        # Set up a timer so we can timeout if not connection is obtained in time
+        loop = asyncio.get_running_loop()
+        end_time = loop.time() + self._timeout
+        while loop.time() < end_time:
+            try:
+                self._conn = await self._stub.OpenConnection(req)  # type: ignore
+                return self
+            except aio.AioRpcError:
+                # We weren't able to establish a connection this try
+                continue
+        else:
+            raise NoServerConnection(f"after {self._timeout} seconds")
 
     def is_connected(self) -> bool:
-        """True if the client has an open connection"""
-        return self._conn is not None
+        """True if the client has an open connection on a ready channel"""
+        return (
+            self._conn is not None
+            and self._channel is not None
+            and self._channel.get_state() is ChannelConnectivity.READY
+        )
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Close the client, cleaning up connections and channels"""
+        if (
+            self._channel is not None
+            and self._channel.get_state() is not ChannelConnectivity.SHUTDOWN
+        ):
+            await self._channel.close()
         # TODO: Send RPC to terminate connection (just a courtesy for the server)
-        self._channel.close()

--- a/chai/chai.py
+++ b/chai/chai.py
@@ -145,7 +145,7 @@ class Chai(Awaitable):
 
         req = msg.ConnectRequest()
 
-        # Set up a timer so we can timeout if not connection is obtained in time
+        # Set up a timer so we can timeout if no connection is obtained in time
         loop = asyncio.get_running_loop()
         end_time = loop.time() + self._timeout
         while loop.time() < end_time:

--- a/integration-tests/test_apalache_integration.py
+++ b/integration-tests/test_apalache_integration.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-
-import pytest
 import socket
 import time
-
+from collections.abc import Iterator
 from subprocess import Popen
+
+import pytest
+
 from chai import Chai
 
 
@@ -77,4 +77,4 @@ def client(server: Popen) -> Iterator[Chai]:
 
 
 def test_can_obtain_a_connection(client: Chai) -> None:
-    assert client.isConnected()
+    assert client.is_connected()

--- a/integration-tests/test_apalache_integration.py
+++ b/integration-tests/test_apalache_integration.py
@@ -1,41 +1,11 @@
 from __future__ import annotations
 
-import socket
-import time
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from subprocess import Popen
 
 import pytest
 
-from chai import Chai
-
-
-# Utility function
-def wait_for_server(server: str, port: int, timeout: int) -> bool:
-    """Ping a server
-
-    Adapated from https://stackoverflow.com/a/67217558/1187277
-    """
-    remaining_time = timeout
-    while remaining_time > 0:
-        socket.setdefaulttimeout(remaining_time)
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            s.connect((server, port))
-        except TimeoutError:
-            # We ran out of time waiting for a connection on the socket
-            return False
-        except OSError:
-            # We weren't able to connect to the socket, wait a bit, and try again
-            remaining_time -= 1
-            time.sleep(1)
-        else:
-            # We connected!
-            s.close()
-            return True
-    else:
-        # We ran out of remaining_time, so give up
-        return False
+from chai import Chai, NoServerConnection
 
 
 # Fixture to start and clean up Apalache's Shai server
@@ -54,12 +24,6 @@ def wait_for_server(server: str, port: int, timeout: int) -> bool:
 def server() -> Iterator[Popen]:
     # TODO Pass port to server explicitly when that is supported
     process = Popen(["apalache-mc", "server"])
-    # Startup can take quite some time, especially on the CI machines
-    timeout_secs = 60
-    if not wait_for_server(Chai.DEFAULT_DOMAIN, Chai.DEFAULT_PORT, timeout_secs):
-        raise RuntimeError(
-            f"Apalache server did not start after {timeout_secs} seconds"
-        )
     yield process
     process.terminate()
 
@@ -69,12 +33,22 @@ def server() -> Iterator[Popen]:
 # NOTE: In contrast to the `server` fixture, we do want to create this once for
 # each test
 @pytest.fixture
-def client(server: Popen) -> Iterator[Chai]:
+async def client(server: Popen) -> AsyncIterator[Chai]:
     # We need to ensure the server is created before we create the client
     _ = server
-    with Chai() as client:
+    async with Chai.create() as client:
         yield client
 
 
-def test_can_obtain_a_connection(client: Chai) -> None:
+async def test_can_obtain_a_connection(client: Chai) -> None:
     assert client.is_connected()
+
+
+async def test_raises_error_after_timeout() -> None:
+    # configure the client to use a non-existent server
+    client = Chai(domain="invalid.domain", port=6666, timeout=0.5)
+    try:
+        with pytest.raises(NoServerConnection):
+            await client.connect()
+    finally:
+        await client.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -226,7 +226,7 @@ pgp = ["gpg"]
 
 [[package]]
 name = "executing"
-version = "0.8.3"
+version = "0.9.0"
 description = "Get the currently executing AST node of a frame, and other information"
 category = "dev"
 optional = false
@@ -256,14 +256,6 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
-
-[[package]]
-name = "grpc"
-version = "1.0.0"
-description = "Please install the official package with: pip install grpcio"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "grpc-stubs"
@@ -748,7 +740,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyright"
-version = "1.1.261"
+version = "1.1.263"
 description = "Command line wrapper for pyright"
 category = "dev"
 optional = false
@@ -781,6 +773,20 @@ tomli = ">=1.0.0"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+
+[package.extras]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "python-lsp-jsonrpc"
@@ -972,7 +978,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -1043,7 +1049,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "cfc9810e2f6f45c9e39137ef9bb65b0bc7a9148baa1b030a37cabec80b8ff0fd"
+content-hash = "433cef893f82e46049dc35cecaef244464577fca7d2e1cf66de26a9777a67116"
 
 [metadata.files]
 appnope = [
@@ -1244,8 +1250,8 @@ dulwich = [
     {file = "dulwich-0.20.45.tar.gz", hash = "sha256:70710dd9ca2a442190c7e506892db074c318ac762e221f7529b8ce34802041b7"},
 ]
 executing = [
-    {file = "executing-0.8.3-py2.py3-none-any.whl", hash = "sha256:d1eef132db1b83649a3905ca6dd8897f71ac6f8cac79a7e58a1a09cf137546c9"},
-    {file = "executing-0.8.3.tar.gz", hash = "sha256:c6554e21c6b060590a6d3be4b82fb78f8f0194d809de5ea7df1c093763311501"},
+    {file = "executing-0.9.0-py2.py3-none-any.whl", hash = "sha256:d07e9a46c85dd507055f7c4c208689faef1bf6a671ae81e91787f307808bacfb"},
+    {file = "executing-0.9.0.tar.gz", hash = "sha256:ade7276b4b108df69b8480064264db856335585efe170833601f30bcaaed7bc7"},
 ]
 filelock = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
@@ -1254,9 +1260,6 @@ filelock = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
-]
-grpc = [
-    {file = "grpc-1.0.0.tar.gz", hash = "sha256:e1aa035512b1cc8d5ce84685f30eae463dad9123d858f5676b1159a2b80eea86"},
 ]
 grpc-stubs = [
     {file = "grpc-stubs-1.24.11.tar.gz", hash = "sha256:b02b0445b264eb3d310a2c14816c440f98f76d4ba2a5746adf148d57cca8b3a5"},
@@ -1583,12 +1586,16 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pyright = [
-    {file = "pyright-1.1.261-py3-none-any.whl", hash = "sha256:56d3a10d0fe938cb26864728e65c02f625fe40b2d4b0babba057ff4ac4479eae"},
-    {file = "pyright-1.1.261.tar.gz", hash = "sha256:bbae6f40d31e61ac5754b45f0a80942a7473dd4ebeb86325d44f200d6a0615e4"},
+    {file = "pyright-1.1.263-py3-none-any.whl", hash = "sha256:6b4061e124a5adead099d07e48d85bcab71b35aed3412f9afcaecffe70320459"},
+    {file = "pyright-1.1.263.tar.gz", hash = "sha256:faab59596f3fc9bcda8ab528e09ccbf5ebdb9d94e6e1b599109cc3ab4eaf00f1"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
     {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.19.0.tar.gz", hash = "sha256:ac4ebf3b6207259750bc32f4c1d8fcd7e79739edbc67ad0c58dd150b1d072fed"},
+    {file = "pytest_asyncio-0.19.0-py3-none-any.whl", hash = "sha256:7a97e37cfe1ed296e2e84941384bdd37c376453912d397ed39293e0916f521fa"},
 ]
 python-lsp-jsonrpc = [
     {file = "python-lsp-jsonrpc-1.0.0.tar.gz", hash = "sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd"},
@@ -1703,8 +1710,8 @@ ujson = [
     {file = "ujson-5.4.0.tar.gz", hash = "sha256:6b953e09441e307504130755e5bd6b15850178d591f66292bba4608c4f7f9b00"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.10-py2.py3-none-any.whl", hash = "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec"},
-    {file = "urllib3-1.26.10.tar.gz", hash = "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"},
+    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
+    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
 ]
 virtualenv = [
     {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^4.0.1"
 black = "^22.6.0"
 isort = "^5.10.1"
 pytest = "^7.1.2"
+pytest-asyncio = "^0.19.0"
 pyright = "^1.1.260"
 mypy-protobuf = "^3.2.0"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# See https://github.com/pytest-dev/pytest-asyncio#auto-mode
+asyncio_mode = auto


### PR DESCRIPTION
Closes #14

## Overview

Many of the operations that users of this library will perform are costly (we already know this from MBT), and since the computations will run on the server side, the bottleneck for the client will always be IO. As such, so we'll need to make non-blocking calls. Since it is best to get this worked out while we still have the simplest core, I've refactored the core functionality added in #10 to use async.

## Principle Changes

- Set up the client to use the `asyncio` api provided by grpc, delegating management of the `channel` to the `grpcio.aio` context manager.
- Move logic that waits for the server to be up and running (with a configurable timeout) into the client.
- Set up integration tests to use an asyncio helper to run the scheduler and manage the async fixtures.

## Reviewing

Most of the diffs are likely clearer viewed side-by-side. The commits are not very small, so not much help to go by commit. Sorry for the relatively large changeset here!