### PR TITLE
Cache Apalche build dirs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,9 +108,20 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/Dependencies.scala') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('apalache/project/Dependencies.scala') }}
           restore-keys: |
             ${{ runner.os }}-sbt-
+            ${{ runner.os }}-
+      #----------------------------------------------
+      #       cache apalche build artifacts
+      #----------------------------------------------
+      - name: Cache Apalche build artifacts
+        uses: actions/cache@v2
+        with:
+          path: apalache/**/target
+          key: ${{ runner.os }}-apalache-${{ hashFiles('apalache/**.scala') }}
+          restore-keys: |
+            ${{ runner.os }}-apalche-
             ${{ runner.os }}-
       #----------------------------------------------
       #       install and set up nix


### PR DESCRIPTION
Since we generally aren't changing apalache here, I'm wondering if we
can speed up CI by caching the build dirs when the source files haven't changed.