### PR TITLE
Add `check` RPC for `Cmd Executor` service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-sbt-${{ hashFiles('project/Dependencies.scala') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('apalache/project/Dependencies.scala') }}
           restore-keys: |
             ${{ runner.os }}-sbt-
             ${{ runner.os }}-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       #----------------------------------------------
@@ -89,7 +89,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       #----------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,8 @@ apalache:
 
 lint:
 	poetry run flake8 .
-	poetry run black .
 	poetry run isort .
-	poetry run pyright .
+	poetry run black . --check
 
 test:
 	poetry run pyright chai/ tests/ integration-tests/

--- a/chai/__init__.py
+++ b/chai/__init__.py
@@ -1,2 +1,3 @@
 from chai.client import NoServerConnection, RpcCallWithoutConnection, RpcErr  # noqa
 from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr  # noqa
+from chai.cmd_executor import ChaiCmdExecutor  # noqa

--- a/chai/__init__.py
+++ b/chai/__init__.py
@@ -1,3 +1,3 @@
-from chai.client import NoServerConnection, RpcCallWithoutConnection, RpcErr  # noqa
-from chai.cmd_executor import ChaiCmdExecutor, CheckingError, TypecheckingError  # noqa
-from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr  # noqa
+from chai.client import NoServerConnection, RpcCallWithoutConnection, RpcErr
+from chai.cmd_executor import ChaiCmdExecutor, CheckingError, TypecheckingError
+from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr

--- a/chai/__init__.py
+++ b/chai/__init__.py
@@ -1,3 +1,3 @@
 from chai.client import NoServerConnection, RpcCallWithoutConnection, RpcErr  # noqa
-from chai.cmd_executor import ChaiCmdExecutor  # noqa
+from chai.cmd_executor import ChaiCmdExecutor, CheckingError, TypecheckingError  # noqa
 from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr  # noqa

--- a/chai/__init__.py
+++ b/chai/__init__.py
@@ -1,3 +1,3 @@
 from chai.client import NoServerConnection, RpcCallWithoutConnection, RpcErr  # noqa
-from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr  # noqa
 from chai.cmd_executor import ChaiCmdExecutor  # noqa
+from chai.trans_explorer import ChaiTransExplorer, LoadModuleErr  # noqa

--- a/chai/client.py
+++ b/chai/client.py
@@ -53,8 +53,12 @@ class Source(str):
 
 
 @dataclass
-class RpcErr:
-    """The base type of application errors returned from an RPC call"""
+class RpcErr(ABC):
+    """The abstract base class of application errors returned from an RPC call
+
+    Attributes:
+        msg: A message explaining the error.
+    """
 
     msg: str
 

--- a/chai/cmd_executor.py
+++ b/chai/cmd_executor.py
@@ -1,0 +1,148 @@
+"""The gRPC client to interact with the CmdExeuctor service provided by
+   Apalache's Shai server"""
+from __future__ import annotations
+from abc import ABC, abstractclassmethod, abstractmethod
+
+from dataclasses import dataclass
+import json
+from typing import List, Optional, Tuple, TypeVar
+from typing_extensions import Self
+
+# TODO remove `type: ignore` when stubs are available for grpc.aio See
+# https://github.com/shabbyrobe/grpc-stubs/issues/22
+import grpc.aio as aio  # type: ignore
+
+import chai.client as client
+import chai.cmdExecutor_pb2 as msg
+import chai.cmdExecutor_pb2_grpc as service
+
+from chai.client import RpcResult
+
+Input = client.Source.Input
+# Derived from JSON encodings
+Counterexample = dict
+TlaModule = dict
+
+
+class UnexpectedErrorException(Exception):
+    """For unexpected errors"""
+
+
+def _ensure_is_pass_error(d: dict) -> None:
+    if d["error_type"] != "pass_failure":
+        raise UnexpectedErrorException(f"Unexpected error receieved from RPC call: {d}")
+
+
+@dataclass
+class CmdExecutorError(ABC):
+    pass_name: str
+
+    @abstractclassmethod
+    def of_dict(cls, _: dict) -> Self:
+        ...
+
+
+@dataclass
+class ParsingError(CmdExecutorError):
+    data: List[Tuple[str, str]]  # location, msg errors
+
+    @classmethod
+    def of_dict(cls, d: dict) -> ParsingError:
+        _ensure_is_pass_error(d)
+
+        data = d["data"]
+        pass_name = data["pass_name"]
+        if pass_name == "BoundedChecker":
+            return ParsingError(pass_name, data)
+        else:
+            raise UnexpectedErrorException(
+                f"Unexpected error receieved from RPC call: {d}"
+            )
+
+
+@dataclass
+class TypecheckingError(CmdExecutorError):
+    errors: List[Tuple[str, str]]  # location, msg errors
+
+    @classmethod
+    def of_dict(cls, d: dict) -> ParsingError | TypecheckingError:
+        _ensure_is_pass_error(d)
+
+        data = d["data"]
+        pass_name = data["pass_name"]
+        if pass_name == "BoundedChecker":
+            return TypecheckingError(pass_name, data)
+        else:
+
+            return ParsingError.of_dict(d)
+
+
+@dataclass
+class CheckingError(CmdExecutorError):
+    checking_result: str
+    counter_example: List[Counterexample]
+
+    @classmethod
+    def of_dict(cls, d: dict) -> ParsingError | TypecheckingError | CheckingError:
+        _ensure_is_pass_error(d)
+
+        data = d["data"]
+        pass_name = data["pass_name"]
+        if pass_name == "BoundedChecker":
+            checking_result = data["error_data"]["checking_result"]
+            if checking_result == "Deadlock":
+                # TODO We should use the same key for both counterexamples
+                counter_examples = data["error_data"]["counterexample"]
+            else:
+                counter_examples = data["error_data"]["counterexamples"]
+            return CheckingError(pass_name, checking_result, counter_examples)
+        else:
+            return TypecheckingError.of_dict(d)
+
+
+E = TypeVar("E")
+CmdExecutorResult = RpcResult[E | TlaModule]
+
+
+def _str_source(spec, aux):
+    return {"source": {"type": "string", "content": spec, "aux": aux}}
+
+
+def _config_json(spec: Input, aux: Optional[List[Input]], cfg: Optional[dict]) -> str:
+    # TODO: error if source already set in config?
+    aux = aux or []
+    config = cfg or {}
+    return json.dumps(config | {"input": _str_source(spec, aux)})
+
+
+class ChaiCmdExecutor(client.Chai[service.CmdExecutorStub]):
+    PING_REQUEST = msg.PingRequest  # type: ignore
+
+    @classmethod
+    def _service(cls, channel: aio.Channel) -> service.CmdExecutorStub:
+        return service.CmdExecutorStub(channel)
+
+    @client._requires_connection
+    async def check(
+        self,
+        spec: client.Source.Input,
+        aux: Optional[List[client.Source.Input]] = None,
+        config: Optional[dict] = None,
+    ) -> CmdExecutorResult[ParsingError | TypecheckingError | CheckingError]:
+        resp: msg.CmdResponse = await self._stub.run(
+            msg.CmdRequest(cmd=msg.Cmd.CHECK, config=_config_json(spec, aux, config))
+        )  # type: ignore
+        if resp.HasField("failure"):
+            return CheckingError.of_dict(json.loads(resp.failure))
+        else:
+            return json.loads(resp.success)
+
+    async def parse(
+        self, module: str, aux: List[str], config: dict
+    ) -> RpcResult[CmdExecutorResult[ParsingError]]:
+        ...
+
+    async def typecheck(
+        self, module: str, aux: List[str], config: dict
+    ) -> RpcResult[CmdExecutorResult[ParsingError]]:
+        ...

--- a/chai/cmd_executor.py
+++ b/chai/cmd_executor.py
@@ -1,21 +1,20 @@
 """The gRPC client to interact with the CmdExeuctor service provided by
    Apalache's Shai server"""
 from __future__ import annotations
-from abc import ABC, abstractclassmethod, abstractmethod
 
-from dataclasses import dataclass
 import json
+from abc import ABC, abstractclassmethod
+from dataclasses import dataclass
 from typing import List, Optional, Tuple, TypeVar
-from typing_extensions import Self
 
 # TODO remove `type: ignore` when stubs are available for grpc.aio See
 # https://github.com/shabbyrobe/grpc-stubs/issues/22
 import grpc.aio as aio  # type: ignore
+from typing_extensions import Self
 
 import chai.client as client
 import chai.cmdExecutor_pb2 as msg
 import chai.cmdExecutor_pb2_grpc as service
-
 from chai.client import RpcResult
 
 Input = client.Source.Input

--- a/chai/cmd_executor.py
+++ b/chai/cmd_executor.py
@@ -24,34 +24,47 @@ TlaModule = dict
 
 
 class UnexpectedErrorException(Exception):
-    """For unexpected errors"""
+    """For unexpected application errors"""
 
 
-def _ensure_is_pass_error(d: dict) -> None:
+@dataclass
+class CmdExecutorError(ABC):
+    """The base class for known application errors returned by the CmdExecutor service
+
+    Attributes:
+        pass_name: The name of the processing pass that produced the error.
+    """
+
+    pass_name: str
+
+    # Derive an error from decoded JSON
+    @abstractclassmethod
+    def _of_dict(cls, _: dict) -> Self:
+        ...
+
+
+def _ensure_is_pass_failure(d: dict) -> None:
     if d["error_type"] != "pass_failure":
         raise UnexpectedErrorException(f"Unexpected error receieved from RPC call: {d}")
 
 
 @dataclass
-class CmdExecutorError(ABC):
-    pass_name: str
-
-    @abstractclassmethod
-    def of_dict(cls, _: dict) -> Self:
-        ...
-
-
-@dataclass
 class ParsingError(CmdExecutorError):
-    data: List[Tuple[str, str]]  # location, msg errors
+    """Records a parsing error
+
+    Attributes:
+        errors: A list of parsing error messages.
+    """
+
+    errors: List[str]
 
     @classmethod
-    def of_dict(cls, d: dict) -> ParsingError:
-        _ensure_is_pass_error(d)
+    def _of_dict(cls, d: dict) -> ParsingError:
+        _ensure_is_pass_failure(d)
 
         data = d["data"]
         pass_name = data["pass_name"]
-        if pass_name == "BoundedChecker":
+        if pass_name == "SanyParser":
             return ParsingError(pass_name, data)
         else:
             raise UnexpectedErrorException(
@@ -61,42 +74,59 @@ class ParsingError(CmdExecutorError):
 
 @dataclass
 class TypecheckingError(CmdExecutorError):
+    """Records a typechecking error
+
+    Attributes:
+        errors: A list of tuples pairing source locations with type error
+            messages.
+    """
+
     errors: List[Tuple[str, str]]  # location, msg errors
 
     @classmethod
-    def of_dict(cls, d: dict) -> ParsingError | TypecheckingError:
-        _ensure_is_pass_error(d)
+    def _of_dict(cls, d: dict) -> ParsingError | TypecheckingError:
+        _ensure_is_pass_failure(d)
 
-        data = d["data"]
-        pass_name = data["pass_name"]
-        if pass_name == "BoundedChecker":
-            return TypecheckingError(pass_name, data)
+        pass_name = d["data"]["pass_name"]
+        errors = d["data"]["error_data"]
+        if pass_name == "TypeCheckerSnowcat":
+            return TypecheckingError(pass_name, errors)
         else:
-
-            return ParsingError.of_dict(d)
+            return ParsingError._of_dict(d)
 
 
 @dataclass
 class CheckingError(CmdExecutorError):
+    """Records a model checking error
+
+    Attributes:
+        checking_result: The kind of model checking result. The possible result kinds are
+            - Error: A checking violation is found.
+            - Deadlock: A deadlock was found.
+            - RuntimeError: A runtime error was encountered, preventing checking.
+        counter_examples: A list of counterexamples found.
+    """
+
     checking_result: str
     counter_example: List[Counterexample]
 
     @classmethod
-    def of_dict(cls, d: dict) -> ParsingError | TypecheckingError | CheckingError:
-        _ensure_is_pass_error(d)
+    def _of_dict(cls, d: dict) -> ParsingError | TypecheckingError | CheckingError:
+        _ensure_is_pass_failure(d)
 
-        data = d["data"]
-        pass_name = data["pass_name"]
+        error_data = d["data"]["error_data"]
+        pass_name = d["data"]["pass_name"]
         if pass_name == "BoundedChecker":
-            checking_result = data["error_data"]["checking_result"]
+            checking_result = error_data["checking_result"]
             if checking_result == "Deadlock":
                 # TODO We should use the same key for both counterexamples
-                counter_examples = data["error_data"]["counterexample"]
+                counter_examples = error_data["counterexample"]
             else:
-                counter_examples = data["error_data"]["counterexamples"]
+                counter_examples = error_data["counterexamples"]
+            # TODO Handle all other checking errors
             return CheckingError(pass_name, checking_result, counter_examples)
         else:
-            return TypecheckingError.of_dict(d)
+            return TypecheckingError._of_dict(d)
 
 
 E = TypeVar("E")
@@ -115,6 +145,42 @@ def _config_json(spec: Input, aux: Optional[List[Input]], cfg: Optional[dict]) -
 
 
 class ChaiCmdExecutor(client.Chai[service.CmdExecutorStub]):
+    r"""Client for Shai's `CmdExecutor` service
+
+    The `CmdExecutor` service is a stateless service exposing the functionality
+    of Apalache's CLI.
+
+    Example usage:
+
+    ```
+    from chai import ChaiCmdExecutor
+
+    async with ChaiCmdExecutor.create() as client:
+        assert client.is_connected()
+        spec = '''
+            ---- MODULE M ----
+            VARIABLES
+                \* @type: Bool;
+                x,
+                \* @type: Bool;
+                y
+
+            Init == x = TRUE /\ y = TRUE
+            Next == x' = FALSE /\ y' = y
+            Inv == x
+            ====
+            '''
+        res = await client.check(spec, config={"checker": {"inv": ["Inv"]}})
+        assert isinstance(res, CheckingError)
+        assert res.checking_result == "Error"
+        states = res.counter_example[0]["states"][1]
+        assert states == {"#meta": {"index": 1}, "x": False, "y": True}
+
+    See the documetation of :class:`~chai.client.Chai` for instruction on using
+    the client safely without a context manager.
+    ```
+    """
+
     PING_REQUEST = msg.PingRequest  # type: ignore
 
     @classmethod
@@ -128,19 +194,29 @@ class ChaiCmdExecutor(client.Chai[service.CmdExecutorStub]):
         aux: Optional[List[client.Source.Input]] = None,
         config: Optional[dict] = None,
     ) -> CmdExecutorResult[ParsingError | TypecheckingError | CheckingError]:
+        """Model check a TLA spec
+
+        Args:
+            spec: The root module, as a string or path to a file.
+            aux: Auxiliary modules extended by the root module.
+            config: Application configuration, as documented in `Apalache's
+                Manual <https://apalache.informal.systems/docs/apalache/config.html#configuration-files>`_
+        """
         resp: msg.CmdResponse = await self._stub.run(
             msg.CmdRequest(cmd=msg.Cmd.CHECK, config=_config_json(spec, aux, config))
         )  # type: ignore
         if resp.HasField("failure"):
-            return CheckingError.of_dict(json.loads(resp.failure))
+            return CheckingError._of_dict(json.loads(resp.failure))
         else:
             return json.loads(resp.success)
 
+    @client._requires_connection
     async def parse(
         self, module: str, aux: List[str], config: dict
     ) -> RpcResult[CmdExecutorResult[ParsingError]]:
         ...
 
+    @client._requires_connection
     async def typecheck(
         self, module: str, aux: List[str], config: dict
     ) -> RpcResult[CmdExecutorResult[ParsingError]]:

--- a/chai/cmd_executor.py
+++ b/chai/cmd_executor.py
@@ -29,7 +29,7 @@ class UnexpectedErrorException(Exception):
 
 @dataclass
 class CmdExecutorError(ABC):
-    """The base class for known application errors returned by the CmdExecutor service
+    """Base class for known application errors
 
     Attributes:
         pass_name: The name of the processing pass that produced the error.
@@ -100,7 +100,9 @@ class CheckingError(CmdExecutorError):
     """Records a model checking error
 
     Attributes:
-        checking_result: The kind of model checking result. The possible result kinds are
+        checking_result: The kind of model checking result. The possible result
+            kinds are as follows
+
             - Error: A checking violation is found.
             - Deadlock: A deadlock was found.
             - RuntimeError: A runtime error was encountered, preventing checking.
@@ -200,7 +202,7 @@ class ChaiCmdExecutor(client.Chai[service.CmdExecutorStub]):
             spec: The root module, as a string or path to a file.
             aux: Auxiliary modules extended by the root module.
             config: Application configuration, as documented in `Apalache's
-                Manual <https://apalache.informal.systems/docs/apalache/config.html#configuration-files>`_
+                Manual <https://apalache.informal.systems/docs/apalache/config.html#configuration-files>`_ # noqa
         """
         resp: msg.CmdResponse = await self._stub.run(
             msg.CmdRequest(cmd=msg.Cmd.CHECK, config=_config_json(spec, aux, config))

--- a/chai/trans_explorer.py
+++ b/chai/trans_explorer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Optional, TypeVar
 
 # TODO remove `type: ignore` when stubs are available for grpc.aio See
@@ -26,8 +27,11 @@ import chai.transExplorer_pb2_grpc as service
 T = TypeVar("T")
 
 
+@dataclass
 class LoadModuleErr(client.RpcErr):
     """Represents an error when loading a module (e.g., a parse error)"""
+
+    msg: str
 
 
 class ChaiTransExplorer(client.Chai[service.TransExplorerStub]):

--- a/integration-tests/test_cmd_executor_integration.py
+++ b/integration-tests/test_cmd_executor_integration.py
@@ -2,18 +2,13 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
 from subprocess import Popen
-from typing import Dict, List
+from typing import List
 
 import pytest
 
-from chai import (
-    ChaiCmdExecutor,
-    LoadModuleErr,
-    NoServerConnection,
-    RpcCallWithoutConnection,
-)
+from chai import ChaiCmdExecutor
 from chai.client import Source
-from chai.cmd_executor import CheckingError, CmdExecutorError
+from chai.cmd_executor import CheckingError
 
 
 # Fixture to start and clean up Apalache's Shai server

--- a/integration-tests/test_cmd_executor_integration.py
+++ b/integration-tests/test_cmd_executor_integration.py
@@ -8,7 +8,6 @@ import pytest
 
 from chai import ChaiCmdExecutor, CheckingError, TypecheckingError
 from chai.client import Source
-from chai.cmd_executor import ParsingError
 
 
 # Fixture to start and clean up Apalache's Shai server
@@ -135,7 +134,7 @@ Next == TRUE
     print(res)
     assert isinstance(res, TypecheckingError)
     # Errors look something like:
-    # [['M.tla:7:9-7:17', 'Arguments to = should have the same type. For arguments x, "foo" with types Bool, Str, in expression x = "foo"'],
+    # [['M.tla:7:9-7:17', 'Arguments to = should have the same type. For arguments x, "foo" with types Bool, Str, in expression x = "foo"'], # noqa
     #  ['M.tla:7:1-7:17', 'Error when computing the type of Init']]
     assert len(res.errors) == 2
 

--- a/integration-tests/test_cmd_executor_integration.py
+++ b/integration-tests/test_cmd_executor_integration.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from subprocess import Popen
+from typing import Dict, List
+
+import pytest
+
+from chai import (
+    ChaiCmdExecutor,
+    LoadModuleErr,
+    NoServerConnection,
+    RpcCallWithoutConnection,
+)
+from chai.client import Source
+from chai.cmd_executor import CheckingError, CmdExecutorError
+
+
+# Fixture to start and clean up Apalache's Shai server
+#
+# - `autouse=True`:
+#
+#   Ensures that the fixture is provided (i.e., that the server is started)
+#   for every test.
+#
+# - `scope="module"`:
+#
+#   Specifies that this fixture is created only once for all tests in the module,
+#   rather than created once per test. See
+#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
+@pytest.fixture(autouse=True, scope="module")
+def server() -> Iterator[Popen]:
+    # TODO Pass port to server explicitly when that is supported
+    process = Popen(["apalache-mc", "server"])
+    yield process
+    process.terminate()
+
+
+# Fixture to provide and clean up a connected client for each test
+#
+# NOTE: In contrast to the `server` fixture, we do want to create this once for
+# each test
+@pytest.fixture
+async def client(server: Popen) -> AsyncIterator[ChaiCmdExecutor]:
+    # We need to ensure the server is created before we create the client
+    _ = server
+    async with ChaiCmdExecutor.create() as client:
+        yield client
+
+
+async def test_can_obtain_a_connection(client: ChaiCmdExecutor) -> None:
+    assert client.is_connected()
+
+
+async def test_can_check_model(client: ChaiCmdExecutor) -> None:
+    spec = """
+---- MODULE M ----
+Init == TRUE
+Next == TRUE
+====
+"""
+    res = await client.check(spec)
+    assert isinstance(res, dict)
+    m = res["modules"][0]
+    assert m["name"] == "M" and m["kind"] == "TlaModule"
+
+
+async def test_can_check_model_with_aux_modules(client: ChaiCmdExecutor) -> None:
+    spec = """
+---- MODULE M ----
+EXTENDS A
+Next == TRUE
+====
+"""
+    aux: List[Source.Input] = [
+        """
+---- MODULE A ----
+Init == TRUE
+====
+"""
+    ]
+    res = await client.check(spec, aux)
+    assert isinstance(res, dict)
+    m = res["modules"][0]
+    decls = m["declarations"]
+    assert any(d["name"].startswith("Init") for d in decls)
+
+
+async def test_deadlocked_model_returns_deadlock_checking_error(
+    client: ChaiCmdExecutor,
+) -> None:
+    spec = """
+---- MODULE M ----
+Init == TRUE
+Next == FALSE
+====
+"""
+    res = await client.check(spec)
+    assert isinstance(res, CheckingError)
+    assert res.checking_result == "Deadlock"
+
+
+async def test_invalid_model_returns_validation_checking_error(
+    client: ChaiCmdExecutor,
+) -> None:
+    spec = r"""
+---- MODULE M ----
+VARIABLES
+    \* @type: Bool;
+    x,
+    \* @type: Bool;
+    y
+
+Init == x = TRUE /\ y = TRUE
+Next == x' = FALSE /\ y' = y
+Inv == x
+====
+"""
+    res = await client.check(spec, config={"checker": {"inv": ["Inv"]}})
+    assert isinstance(res, CheckingError)
+    assert res.checking_result == "Error"
+    states = res.counter_example[0]["states"][1]
+    assert states == {"#meta": {"index": 1}, "x": False, "y": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Shon Feder <shon@informal.systems>"]
 license = "Apache2.0"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 grpcio-tools = "^1.47.0"
 poetry = {version = "^1.2.0b3", allow-prereleases = true}
 grpcio = "^1.47.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,7 @@ max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
+
+# TODO: remove once package is stabilized
+# Ignore unused imports in __init__ while in rapid development
+per-file-ignores = __init__.py:F401


### PR DESCRIPTION
This adds client support for running the `check` command via RPCs.

The change is pretty straightforward: just plumbing data through and adding a bit of abstraction around the representation of application errors.

I've left implementation of type checking and parsing RPCs as a followup, to keep the diff from being too huge.

There's also some followup work required to fix the way parsing errors are returned in Apalache. See https://github.com/informalsystems/apalache/issues/2199