### PR TITLE
Add a blocking interface for the ChaiCmdExecutor

### DIFF
--- a/chai/blocking/__init__.py
+++ b/chai/blocking/__init__.py
@@ -1,0 +1,1 @@
+from chai.blocking.cmd_executor import ChaiCmdExecutor

--- a/chai/blocking/cmd_executor.py
+++ b/chai/blocking/cmd_executor.py
@@ -1,0 +1,69 @@
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from typing_extensions import Self
+
+import chai
+from chai.blocking.utils import make_blocking
+from chai.cmd_executor import (
+    CmdExecutorCheckError,
+    CmdExecutorParseError,
+    CmdExecutorResult,
+    CmdExecutorTypecheckError,
+)
+from chai.source import Source
+
+
+class ChaiCmdExecutor:
+    """A blocking alternative for the async :class:`~chai.ChaiCmdExecutor`
+
+    See the async interface for documentation on the available methods.
+    """
+
+    def __init__(
+        self,
+        domain: Optional[str] = None,
+        port: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self._async = chai.ChaiCmdExecutor(domain, port, timeout)
+
+    @classmethod
+    @contextmanager
+    def create(cls, *args: Any, **kwargs: Any) -> Iterator[Self]:
+        client = cls(*args, **kwargs)
+
+        @make_blocking
+        async def connect_client():
+            await client._async.connect()
+
+        @make_blocking
+        async def close_client():
+            await client._async.close()
+
+        try:
+            _ = connect_client()
+            yield client
+        finally:
+            _ = close_client()
+
+    def is_connected(self) -> bool:
+        return self._async.is_connected()
+
+    @make_blocking
+    async def check(
+        self, input: Source, config: Optional[dict] = None
+    ) -> CmdExecutorResult[CmdExecutorCheckError]:
+        return await self._async.check(input, config)
+
+    @make_blocking
+    async def parse(
+        self, input: Source, config: Optional[dict] = None
+    ) -> CmdExecutorResult[CmdExecutorParseError]:
+        return await self._async.parse(input, config)
+
+    @make_blocking
+    async def typecheck(
+        self, input: Source, config: Optional[dict] = None
+    ) -> CmdExecutorResult[CmdExecutorTypecheckError]:
+        return await self._async.typecheck(input, config)

--- a/chai/blocking/utils.py
+++ b/chai/blocking/utils.py
@@ -1,0 +1,17 @@
+import asyncio
+import functools
+
+
+def make_blocking(f):
+    """
+    Wrapper to make an async function run as a blocking function
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        result = f(*args, **kwargs)
+        if asyncio.iscoroutine(result):
+            return asyncio.get_event_loop().run_until_complete(result)
+        return result
+
+    return wrapper

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixutres for all tests
+
+See https://pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from subprocess import Popen
+
+import pytest
+
+# Fixture to start and clean up Apalache's Shai server
+#
+# - `autouse=True`:
+#
+#   Ensures that the fixture is provided (i.e., that the server is started)
+#   for every test.
+#
+# - `scope="session"`:
+#
+#   Specifies that this fixture is created only once for all the tests in any test session,
+#   rather than created once per test. I.e., we only share a single server between all the clients
+#   tested in all of our test files. See
+#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
+@pytest.fixture(autouse=True, scope="session")
+def server() -> Iterator[Popen]:
+    # TODO Pass port to server explicitly when that is supported
+    process = Popen(["apalache-mc", "server"])
+    yield process
+    process.terminate()

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from subprocess import Popen
+from pathlib import Path
+import os
 
 import pytest
 
@@ -27,7 +29,13 @@ import pytest
 #   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session # noqa: E501
 @pytest.fixture(autouse=True, scope="session")
 def server() -> Iterator[Popen]:
+    this_dir = Path(os.path.dirname(os.path.realpath(__file__)))
+    apalache_dir = this_dir / ".." / "apalache"
+    # We run apalche in its nix flake to ensure all dependencies are set to the
+    # right version. Without this guard, different CI environments may use different
+    # java versions when running apalache.
+    # See https://github.com/informalsystems/apalache-chai/issues/24
     # TODO Pass port to server explicitly when that is supported
-    process = Popen(["apalache-mc", "server"])
+    process = Popen(["nix", "develop", "-c", "apalache-mc", "server"], cwd=apalache_dir)
     yield process
     process.terminate()

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared fixutres for all tests
 
-See https://pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
+See https://pytest.org/en/latest/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files # noqa: E501
 """
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from subprocess import Popen
 
 import pytest
+
 
 # Fixture to start and clean up Apalache's Shai server
 #
@@ -18,10 +19,12 @@ import pytest
 #
 # - `scope="session"`:
 #
-#   Specifies that this fixture is created only once for all the tests in any test session,
-#   rather than created once per test. I.e., we only share a single server between all the clients
+#   Specifies that this fixture is created only once for all the tests in any
+#   test session, rather than created once per test. I.e., we only share a
+#   single server between all the clients
+#
 #   tested in all of our test files. See
-#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
+#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session # noqa: E501
 @pytest.fixture(autouse=True, scope="session")
 def server() -> Iterator[Popen]:
     # TODO Pass port to server explicitly when that is supported

--- a/integration-tests/test_cmd_executor_blocking_integration.py
+++ b/integration-tests/test_cmd_executor_blocking_integration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from subprocess import Popen
+
+import pytest
+
+from chai.blocking import ChaiCmdExecutor
+from chai.source import Source
+
+
+# Fixture to provide and clean up a connected client for each test
+#
+# NOTE: In contrast to the `server` fixture, we do want to create this once for
+# each test
+@pytest.fixture
+def client(server: Popen) -> Iterator[ChaiCmdExecutor]:
+    # We need to ensure the server is created before we create the client
+    _ = server
+    with ChaiCmdExecutor.create() as client:
+        yield client
+
+
+def test_can_obtain_a_blocking_connection(client: ChaiCmdExecutor) -> None:
+    assert client.is_connected()
+
+
+# NOTE: The following tests are just blocking versions of the happypath
+# tests in `test_cmd_executor_integration.py`
+#
+# We do not exercise any of the error-handling functionality, since that is
+# already covered in the async tests. Here, we only need to confirm that
+# blocking calls can indeed be made.
+
+
+def test_can_check_blocking_model(client: ChaiCmdExecutor) -> None:
+    spec = """
+---- MODULE M ----
+Init == TRUE
+Next == TRUE
+====
+"""
+    res = client.check(Source(spec))
+    assert isinstance(res, dict)
+    m = res["modules"][0]
+    assert m["name"] == "M" and m["kind"] == "TlaModule"
+
+
+def test_typechecking_a_well_typed_model_blocking_succeeds(
+    client: ChaiCmdExecutor,
+) -> None:
+    spec = r"""
+---- MODULE M ----
+EXTENDS Integers
+VARIABLES
+    \* @type: Int;
+    x
+
+Add1 == x + 1
+====
+"""
+    res = client.typecheck(Source(spec))
+    # We get a dictionary back
+    assert isinstance(res, dict)
+    # And the dictionary is an Apalache IR representation of the module
+    assert res["name"] == "ApalacheIR"
+
+
+def test_parsing_a_valid_model_blocking_succeeds(
+    client: ChaiCmdExecutor,
+) -> None:
+    spec = r"""
+---- MODULE M ----
+Foo == TRUE
+====
+"""
+    res = client.parse(Source(spec))
+    # We get a dictionary back
+    assert isinstance(res, dict)
+    # And the dictionary is an Apalache IR representation of the module
+    assert res["name"] == "ApalacheIR"

--- a/integration-tests/test_cmd_executor_integration.py
+++ b/integration-tests/test_cmd_executor_integration.py
@@ -11,26 +11,6 @@ from chai.cmd_executor import ParsingError
 from chai.source import Source
 
 
-# Fixture to start and clean up Apalache's Shai server
-#
-# - `autouse=True`:
-#
-#   Ensures that the fixture is provided (i.e., that the server is started)
-#   for every test.
-#
-# - `scope="module"`:
-#
-#   Specifies that this fixture is created only once for all tests in the module,
-#   rather than created once per test. See
-#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
-@pytest.fixture(autouse=True, scope="module")
-def server() -> Iterator[Popen]:
-    # TODO Pass port to server explicitly when that is supported
-    process = Popen(["apalache-mc", "server"])
-    yield process
-    process.terminate()
-
-
 # Fixture to provide and clean up a connected client for each test
 #
 # NOTE: In contrast to the `server` fixture, we do want to create this once for

--- a/integration-tests/test_cmd_executor_integration.py
+++ b/integration-tests/test_cmd_executor_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from pathlib import Path
 from subprocess import Popen
 

--- a/integration-tests/test_trans_explorer_integration.py
+++ b/integration-tests/test_trans_explorer_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from subprocess import Popen
 
 import pytest
@@ -11,26 +11,6 @@ from chai import (
     NoServerConnection,
     RpcCallWithoutConnection,
 )
-
-
-# Fixture to start and clean up Apalache's Shai server
-#
-# - `autouse=True`:
-#
-#   Ensures that the fixture is provided (i.e., that the server is started)
-#   for every test.
-#
-# - `scope="module"`:
-#
-#   Specifies that this fixture is created only once for all tests in the module,
-#   rather than created once per test. See
-#   https://docs.pytest.org/en/6.2.x/fixture.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
-@pytest.fixture(autouse=True, scope="module")
-def server() -> Iterator[Popen]:
-    # TODO Pass port to server explicitly when that is supported
-    process = Popen(["apalache-mc", "server"])
-    yield process
-    process.terminate()
 
 
 # Fixture to provide and clean up a connected client for each test


### PR DESCRIPTION
Closes #35

This adds a block API for the `CmdExecutor` client. The blocking interface is
derived by application of a simple decorator over some copy-pasta.

If we end up with a lot of client methods, we can automate the derivation of
sync intefaces via dynamic constrution of classes, but that's overkill for now
given that we only need to expose 3 methods.