### PR TITLE
Fix macOS CI `System Integrity Protection` issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
             ${{ runner.os }}-nix-
             ${{ runner.os }}-
       - name: Install Nix
-        uses: cachix/install-nix-action@v14.1
+        uses: cachix/install-nix-action@v22
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
Fixes the `Operation not permitted while System Integrity Protection is engaged` [CI error on macOS](https://github.com/informalsystems/apalache-chai/actions/runs/5389788576/jobs/9784233462?pr=45) by bumping the version of the `cachix/install-nix-action` action, as [suggested upstream](https://github.com/cachix/install-nix-action/issues/183#issuecomment-1595162172).